### PR TITLE
chore: update signer download link

### DIFF
--- a/src/components/Modal/missingRequiredSoftwareModal.tsx
+++ b/src/components/Modal/missingRequiredSoftwareModal.tsx
@@ -73,7 +73,7 @@ function MissingRequiredSoftwareModal() {
           <p className={classNames('pl-16', {'pt-6': (keyring === false)})}>
             Install{' '}
             <a
-              href="https://github.com/Manta-Network/manta-signer/releases/"
+              href="https://signer.manta.network/"
               className="link-text"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/Modal/newerSignerVersionRequiredModal.tsx
+++ b/src/components/Modal/newerSignerVersionRequiredModal.tsx
@@ -24,7 +24,7 @@ function NewerSignerVersionRequiredModal() {
         <p className="pl-16">
           You must uninstall Manta Signer and download{' '}
           <a
-            href="https://github.com/Manta-Network/manta-signer/releases/"
+            href="https://signer.manta.network/"
             className="link-text"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
Updates signer download links to point to the new landing page instead of github download page