### PR TITLE
fix: input value change after transaction completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [\#198](https://github.com/Manta-Network/manta-front-end/pull/198) Bump react-router-dom from 5.3.3 to 6.3.0 (required refactoring of breaking API changes)
 - [\#201](https://github.com/Manta-Network/manta-front-end/pull/201) Bump @craco/craco from 6.4.3 to 6.4.5
 - [\#117](https://github.com/Manta-Network/manta-front-end/pull/117) Bump node-sass from 6.0.1 to 7.0.1
+
+## [3.1.1] - 2022-11-6
+
+### Fixed
+- [\#245](https://github.com/Manta-Network/manta-front-end/pull/245) Don't show insufficient funds text after transaction

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-web-app",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "private": false,
     "dependencies": {
         "@craco/craco": "^6.4.5",

--- a/src/config/common.json
+++ b/src/config/common.json
@@ -1,5 +1,5 @@
 {
-    "VERSION": "3.1.0",
+    "VERSION": "3.1.1",
     "DOWNTIME": false,
     "BASE_STORAGE_KEY": "mantaWebApp",
     "PAGE_TITLE": "Manta dApp",
@@ -10,7 +10,8 @@
         "mantaPay": {
             "pull_ledger_diff": {
                 "description": "pull from mantaPay",
-                "params": [{
+                "params": [
+                    {
                         "name": "checkpoint",
                         "type": "Checkpoint"
                     },

--- a/src/pages/SendPage/SendFromForm/SendAmountInput.tsx
+++ b/src/pages/SendPage/SendFromForm/SendAmountInput.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { useTxStatus } from 'contexts/txStatusContext';
@@ -27,10 +27,18 @@ const SendAmountInput = () => {
   const [inputValue, setInputValue] = useState('');
 
   const shouldShowLoader = !senderAssetCurrentBalance && api?.isConnected;
-  const shouldShowInitialSync = shouldShowLoader && isInitialSync.current && senderIsPrivate();
+  const shouldShowInitialSync =
+    shouldShowLoader && isInitialSync.current && senderIsPrivate();
   const balanceText = shouldShowInitialSync
-    ? 'Syncing to network' : senderAssetCurrentBalance?.toString(true);
+    ? 'Syncing to network'
+    : senderAssetCurrentBalance?.toString(true);
   const disabled = txStatus?.isProcessing();
+
+  useEffect(() => {
+    if (!shouldShowLoader) {
+      onChangeSendAmountInput('');
+    }
+  }, [balanceText]);
 
   const onChangeSendAmountInput = (value) => {
     if (value === '') {


### PR DESCRIPTION
## Description

closes: #245 

Modified the SendAmountInput component.

Added a useEffect hook with a dependency to listen for balance changes, when detected refreshes the input value.

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [ ] Re-reviewed files changed in the Github PR explorer

## If PR to `staging`
- [ ] Updated relevant documentation in the code
- [ ] Test code changes manually, and describe your procedure in a comment on this PR
- [ ] Mark this PR with the correct milestone

## If PR to `main`
- [ ] Update the version number in `package.json` and `src/config/common.json`
- [ ] Update the minimum required signer version number in `src/config/common.json` if applicable
- [ ] Test following the procedure in `docs/manual_test.md`
- [ ] Update `CHANGELOG.md`
- [ ] Make sure that all PR's to `manta-signer` and `sdk` on which this PR depends are merged
