### PR TITLE
Add CertHum collator to name map

### DIFF
--- a/src/types/Collator.ts
+++ b/src/types/Collator.ts
@@ -39,6 +39,7 @@ const ADDRESS_TO_COLLATOR_NAME_MAP = {
   dmyxfU1bJM5UR5RWsypKm9KQDkVofm3ifp5gVjzs8uQHUmBZb: 'pathrocknetwork',
   dmvVY24KwgNwoYnHw5EbC8mTUF9CtZeJzCnSGBawWzaRkNHH4: 'lets_node',
   dmyhNFR1qUuA8efaYvpW75qGKrYfzrK8ejygttHojeL4ujzUb: '🧊Iceberg Nodes🧊 | C1',
+  dmu7ke7UqHb9oh4zbA9z7sUe9SjTEqqXyWF39dXva2aBuYyDR: 'CertHum',
   // test collators
   dmyjURuBeJwFo4Nvf2GZ8f5E2Asz98JY2d7UcaDykqYm1zpoi: 'Alice',
   dmxAK9q1WBDFtuNS9bLbBujK452yFfm8h8HLHWrr5mZqnEBi2: 'Bob',


### PR DESCRIPTION
Adding CertHum's collator as per their request

Signed-off-by: Adam Reif <garandor@manta.network>

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [ ] Re-reviewed files changed in the Github PR explorer

## If PR to `staging`
- [ ] Updated relevant documentation in the code
- [ ] Test code changes manually, and describe your procedure in a comment on this PR
- [ ] Mark this PR with the correct milestone

## If PR to `main`
- [ ] Update the version number in `package.json` and `src/config/common.json`
- [ ] Update the minimum required signer version number in `src/config/common.json` if applicable
- [ ] Test following the procedure in `docs/manual_test.md`
- [ ] Update `CHANGELOG.md`
- [ ] Make sure that all PR's to `manta-signer` and `sdk` on which this PR depends are merged
