### PR TITLE
remove ip block from pages besides mantapay on calamari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,3 +204,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [\#711](https://github.com/Manta-Network/manta-front-end/pull/711) Add Giant Squid activity banner
+
+## [5.0.2] - 2023-3-15
+
+### Added
+- [\#715](https://github.com/Manta-Network/manta-front-end/pull/715) Remove country-level IP blocking from all pages except MantaPay on Calamari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,5 +207,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [5.0.2] - 2023-3-15
 
-### Added
-- [\#715](https://github.com/Manta-Network/manta-front-end/pull/715) Remove country-level IP blocking from all pages except MantaPay on Calamari
+### Fixed
+- [\#751](https://github.com/Manta-Network/manta-front-end/pull/751) Remove country-level IP blocking from all pages except MantaPay on Calamari
+- [\#742](https://github.com/Manta-Network/manta-front-end/pull/742) Stop blocking Hong Kong and Macau IPs
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manta-web-app",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "private": false,
     "dependencies": {
         "@acala-network/api": "^4.1.6-29",

--- a/src/components/Modal/IPBlockingModal.tsx
+++ b/src/components/Modal/IPBlockingModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useModal } from 'hooks';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 const blockedCountries = ['US', 'CN', 'IR', 'CU', 'KP', 'SY', 'MM'];
 const blockedRegions = ['Crimea', 'Luhans\'k', 'Donets\'k'];
@@ -8,6 +9,8 @@ const IPDATA_APIKEY = 'f47f1429b7dfb0d01a6d049b7cd283087b1b75fc3891f249d9c0919b'
 
 function IPBlockingModal() {
   const { ModalWrapper, showModal, hideModal } = useModal({ closeDisabled: true });
+  const navigate = useNavigate();
+
 
   useEffect(() => {
     async function getUserGeolocation() {
@@ -15,7 +18,6 @@ function IPBlockingModal() {
         hideModal();
         return;
       }
-      showModal();
       const res = await axios.get(`https://api.ipdata.co?api-key=${IPDATA_APIKEY}`);
       if (res.status === 200) {
         const country_code = res?.data?.country_code;
@@ -28,15 +30,33 @@ function IPBlockingModal() {
     getUserGeolocation().catch(console.error);
   }, []);
 
+  const onClickStake = () => {
+    navigate('/calamari/stake');
+  };
+
+  const onClickTestnet = () => {
+    navigate('/dolphin/bridge');
+  };
+
   return (
     <ModalWrapper>
       <div className="w-140 bg-fourth -mx-6 -my-4 rounded-lg p-6">
         <div className="text-xl leading-6">MANTAPAY IS NOT AVAILABLE IN YOUR LOCATION</div>
         <div className="text-sm text-secondary leading-5 my-4">
-          It appears that this connecting is from a prohibited region(United States, China, Iran, Cuba, North Korea, Syria, Myanmar (Burma), the regions of Crimea, Donetsk or Luhansk). If you're using a VPN, try disabling it.
+          It appears that this connecting is from a prohibited region (United States, China, Iran, Cuba, North Korea, Syria, Myanmar (Burma), the regions of Crimea, Donetsk or Luhansk). If you're using a VPN, try disabling it. You can explore other products/services:
         </div>
-        <div className="flex justify-center">
-          <button onClick={() => location.reload()} className="w-44 h-9 text-sm gradient-button cursor-pointer rounded-lg">Refresh</button>
+        <div className="flex justify-center gap-4">
+          <button onClick={onClickStake} className="w-32 h-9 cursor-hover text-sm gradient-button cursor-pointer rounded-lg">$KMA Staking</button>
+          <a
+            className="hover:none"
+            href="https://forum.manta.network/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <button className="w-36 h-9 cursor-hover text-sm text-white gradient-button cursor-pointer rounded-lg">Governance</button>
+          </a>
+          <button onClick={onClickTestnet} className="w-36 h-9 cursor-hover text-sm gradient-button cursor-pointer rounded-lg">Dolphin Testnet</button>
+
         </div>
       </div>
     </ModalWrapper>

--- a/src/components/Modal/IPBlockingModal.tsx
+++ b/src/components/Modal/IPBlockingModal.tsx
@@ -7,10 +7,15 @@ const blockedRegions = ['Crimea', 'Luhans\'k', 'Donets\'k'];
 const IPDATA_APIKEY = 'f47f1429b7dfb0d01a6d049b7cd283087b1b75fc3891f249d9c0919b';
 
 function IPBlockingModal() {
-  const { ModalWrapper, showModal} = useModal({ closeDisabled: true });
+  const { ModalWrapper, showModal, hideModal } = useModal({ closeDisabled: true });
 
   useEffect(() => {
     async function getUserGeolocation() {
+      if (!window.location.pathname.includes('/calamari/transact')) {
+        hideModal();
+        return;
+      }
+      showModal();
       const res = await axios.get(`https://api.ipdata.co?api-key=${IPDATA_APIKEY}`);
       if (res.status === 200) {
         const country_code = res?.data?.country_code;

--- a/src/config/common.json
+++ b/src/config/common.json
@@ -1,5 +1,5 @@
 {
-    "VERSION": "5.0.1",
+    "VERSION": "5.0.2",
     "DOWNTIME": false,
     "PAGE_TITLE": "Manta dApp",
     "MIN_REQUIRED_SIGNER_VERSION": "1.2.1",


### PR DESCRIPTION
## Description

Removes modal that blockers users in restricted locations from all pages except MantaPay on Calamari

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [x] Re-reviewed files changed in the Github PR explorer

## If PR to `main`
- [x] Update the version number in `package.json` and `src/config/common.json`
- [x] Update the minimum required signer version number in `src/config/common.json` if applicable
- [x] Update `CHANGELOG.md`
- [x] Make sure that all PR's to `manta-signer` and `sdk` on which this PR depends are merged
