### PR TITLE
fix: keep usingMantaWallet state

### DIFF
--- a/src/contexts/globalContexts.tsx
+++ b/src/contexts/globalContexts.tsx
@@ -1,32 +1,47 @@
 // @ts-nocheck
 import { localStorageKeys } from 'constants/LocalStorageConstants';
-import React, { createContext, useContext, useCallback, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import store from 'store';
 import { KeyringContextProvider } from './keyringContext';
 import { ThemeProvider } from './themeContext';
 
 const GlobalContext = createContext();
 
-const GlobalContextProvider = ({children}) => {
-  const [usingMantaWallet, _setUsingMantaWallet] = useState(store.get(localStorageKeys.UsingMantaWallet) || true);
+const GlobalContextProvider = ({ children }) => {
+  const [usingMantaWallet, _setUsingMantaWallet] = useState(true);
+  const _usingMantaWallet = store.get(localStorageKeys.UsingMantaWallet);
+
+  useEffect(() => {
+    if (_usingMantaWallet !== undefined) {
+      _setUsingMantaWallet(_usingMantaWallet);
+    }
+  }, [_usingMantaWallet]);
 
   const setUsingMantaWallet = useCallback((state) => {
     _setUsingMantaWallet(state);
     store.set(localStorageKeys.UsingMantaWallet, state);
   }, []);
 
-  const contextValue = useMemo(() => ({
-    usingMantaWallet,
-    setUsingMantaWallet
-  }), [usingMantaWallet, setUsingMantaWallet]);
+  const contextValue = useMemo(
+    () => ({
+      usingMantaWallet,
+      setUsingMantaWallet
+    }),
+    [usingMantaWallet, setUsingMantaWallet]
+  );
 
   return (
     <GlobalContext.Provider value={contextValue}>
       <KeyringContextProvider>
-        <ThemeProvider>
-          {children}
-        </ThemeProvider >
+        <ThemeProvider>{children}</ThemeProvider>
       </KeyringContextProvider>
     </GlobalContext.Provider>
   );
@@ -37,8 +52,7 @@ GlobalContextProvider.propTypes = {
 };
 
 export const useGlobal = () => ({
-  ...useContext(GlobalContext),
+  ...useContext(GlobalContext)
 });
 
 export default GlobalContextProvider;
-


### PR DESCRIPTION
## Description

when user switch to signer, after refresh browser it should be kept.

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [ ] Re-reviewed files changed in the Github PR explorer

## If PR to `staging`
- [ ] Updated relevant documentation in the code
- [ ] Test code changes manually, and describe your procedure in a comment on this PR
- [ ] Mark this PR with the correct milestone

## If PR to `main`
- [ ] Update the version number in `package.json` and `src/config/common.json`
- [ ] Update the minimum required signer version number in `src/config/common.json` if applicable
- [ ] Test following the procedure in `docs/manual_test.md`
- [ ] Update `CHANGELOG.md`
- [ ] Make sure that all PR's to `manta-signer` and `sdk` on which this PR depends are merged
