### PR TITLE
chore: update manta wallet sync

### DIFF
--- a/src/contexts/mantaWalletContext.tsx
+++ b/src/contexts/mantaWalletContext.tsx
@@ -1,7 +1,7 @@
-import WALLET_NAME from 'constants/WalletConstants';
 import { SubmittableExtrinsic } from '@polkadot/api/types';
 import { EventRecord, ExtrinsicStatus } from '@polkadot/types/interfaces';
 import { BN } from 'bn.js';
+import WALLET_NAME from 'constants/WalletConstants';
 import {
   MutableRefObject,
   ReactNode,
@@ -74,7 +74,7 @@ export const MantaWalletContextProvider = ({
   const [hasFinishedInitialBlockDownload, setHasFinishedInitialBlockDownload] =
     useState<boolean | null>(null);
   const [isBusy, setIsBusy] = useState<boolean>(false);
-  const isInitialSync = useRef<boolean>(true);
+  const isInitialSync = useRef<boolean>(false);
 
   // transaction state
   const txQueue = useRef<SubmittableExtrinsic<'promise', any>[]>([]);
@@ -158,33 +158,11 @@ export const MantaWalletContextProvider = ({
     if (privateWallet && !isBusy && isReady) {
       try {
         await privateWallet.walletSync();
-        isInitialSync.current = false;
       } catch (error) {
         console.error('error syncing wallet', error);
       }
     }
   }, [privateWallet, isBusy, isReady]);
-
-  useEffect(() => {
-    const initialSync = async () => {
-      if (isInitialSync.current) {
-        await sync();
-      }
-    };
-    initialSync();
-  }, [isBusy, isReady, isInitialSync.current, privateWallet]);
-
-  useEffect(() => {
-    let interval: ReturnType<typeof setInterval>;
-    if (usingMantaWallet) {
-      interval = setInterval(async () => {
-        if (isReady && usingMantaWallet) {
-          sync();
-        }
-      }, 60000);
-    }
-    return () => clearInterval(interval);
-  }, [isReady, usingMantaWallet]);
 
   const handleInternalTxRes = async ({
     status,

--- a/src/pages/SendPage/SendContext/index.tsx
+++ b/src/pages/SendPage/SendContext/index.tsx
@@ -497,11 +497,11 @@ export const SendContextProvider = (props) => {
       // Correct private balances will only appear after a sync has completed
       // Until then, do not display stale balances
       privateWallet.setBalancesAreStale(true);
+      privateWallet.sync();
       senderAssetType.isPrivate && setSenderAssetCurrentBalance(
         null, senderPublicAccount?.address, senderAssetType
       );
       receiverAssetType.isPrivate && setReceiverCurrentBalance(null, receiverAssetType);
-      privateWallet.sync();
     } catch (error) {
       console.error(error);
     }
@@ -516,8 +516,8 @@ export const SendContextProvider = (props) => {
     setTxStatus(TxStatus.processing());
 
     if (usingMantaWallet) {
-      await privateWallet.sync();
-      if (!isValidToSend()) {
+      const syncSuccess = await privateWallet.sync();
+      if (!isValidToSend() || !syncSuccess) {
         setTxStatus(TxStatus.failed());
         return;
       }


### PR DESCRIPTION
## Description

For manta wallet's walletSync logic:
1. before each private transaction, we need do sync and ensure await privateWallet.walletSync() return true.
2. after transaction is isFinalized.

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [ ] Re-reviewed files changed in the Github PR explorer

## If PR to `staging`
- [ ] Updated relevant documentation in the code
- [ ] Test code changes manually, and describe your procedure in a comment on this PR
- [ ] Mark this PR with the correct milestone
