### PR TITLE
Revert "keep manta wallet name same as extension (#976)"

### DIFF
--- a/src/utils/display/getWalletDisplayName.ts
+++ b/src/utils/display/getWalletDisplayName.ts
@@ -10,7 +10,7 @@ const getWalletDisplayName = (name: string) => {
   } else if (name === WALLET_NAME.SUBWALLET) {
     return 'SubWallet';
   } else if (name === WALLET_NAME.MANTA) {
-    return 'Manta Wallet';
+    return 'MantaWallet';
   } else {
     return name.charAt(0).toUpperCase() + name.slice(1);
   }


### PR DESCRIPTION
This reverts commit 52ac8a0e03439446f5bce10548426537506f05b5.

## Description

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been checked off. If any of the checklist items are not applicable, please leave them but write a little note why.

- [ ] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work
- [ ] Re-reviewed files changed in the Github PR explorer

## If PR to `staging`
- [ ] Updated relevant documentation in the code
- [ ] Test code changes manually, and describe your procedure in a comment on this PR
- [ ] Mark this PR with the correct milestone

## If PR to `main`
- [ ] Update the version number in `package.json` and `src/config/common.json`
- [ ] Update the minimum required signer version number in `src/config/common.json` if applicable
- [ ] Update `CHANGELOG.md`
- [ ] Make sure that all PR's to `manta-signer` and `sdk` on which this PR depends are merged
